### PR TITLE
Column keys don't need to be symbols

### DIFF
--- a/lib/houser/middleware.rb
+++ b/lib/houser/middleware.rb
@@ -27,7 +27,7 @@ module Houser
     private
 
     def find_tenant(env, subdomain)
-      object = options[:class].where(options[:subdomain_column].to_sym => subdomain).first
+      object = options[:class].where(options[:subdomain_column] => subdomain).first
       if object
         env['X-Houser-Subdomain'] = subdomain
         env['X-Houser-Object'] = object


### PR DESCRIPTION
The only reason I care is that this is a middleware
and that means we're (needlessly) adding to _every_ 
request that comes through this middleware.

It tends to count on large applications.

If the change isn't something you'd like I'll understand.
