### PR TITLE
X-headers are a deprecated practice

### DIFF
--- a/lib/houser/middleware.rb
+++ b/lib/houser/middleware.rb
@@ -29,8 +29,8 @@ module Houser
     def find_tenant(env, subdomain)
       object = options[:class].where(options[:subdomain_column].to_sym => subdomain).first
       if object
-        env['X-Houser-Subdomain'] = subdomain
-        env['X-Houser-Object'] = object
+        env['Houser-Namespace'] = subdomain
+        env['Houser-Object'] = object
       end
     end
   end

--- a/spec/houser_spec.rb
+++ b/spec/houser_spec.rb
@@ -29,7 +29,7 @@ describe Houser::Middleware do
   it "does nothing for non-subdomained requests" do
     expect(Account).to_not receive(:where)
     code, env = middleware.call(env_for("http://example.com"))
-    expect(env['X-Houser-Subdomain']).to be_nil
+    expect(env['X-Houser-Namespace']).to be_nil
     expect(env['X-Houser-Object']).to be_nil
   end
 
@@ -37,15 +37,15 @@ describe Houser::Middleware do
     account = double(id: 1)
     expect(Account).to receive(:where).with(subdomain: subdomain).and_return([account])
     code, env = middleware.call(env_for("http://#{subdomain}.example.com"))
-    expect(env['X-Houser-Subdomain']).to eq(subdomain)
-    expect(env['X-Houser-Object']).to eq(account)
+    expect(env['Houser-Namespace']).to eq(subdomain)
+    expect(env['Houser-Object']).to eq(account)
   end
 
   it "returns no headers for unknown subdomains" do
     expect(Account).to receive(:where).with(subdomain: subdomain).and_return([])
     code, env = middleware.call(env_for("http://#{subdomain}.example.com"))
-    expect(env['X-Houser-Subdomain']).to be_nil
-    expect(env['X-Houser-Object']).to be_nil
+    expect(env['Houser-Namespace']).to be_nil
+    expect(env['Houser-Object']).to be_nil
   end
 
 
@@ -56,8 +56,8 @@ describe Houser::Middleware do
       account = double(id: 1)
       expect(Account).to receive(:where).with(subdomain: subdomain).and_return([account])
       code, env = middleware.call(env_for("http://#{subdomain}.example.com"))
-      expect(env['X-Houser-Subdomain']).to eq(subdomain)
-      expect(env['X-Houser-Object']).to eq(account)
+      expect(env['Houser-Namespace']).to eq(subdomain)
+      expect(env['Houser-Object']).to eq(account)
     end
   end
 
@@ -78,8 +78,8 @@ describe Houser::Middleware do
       expect(Account).to_not receive(:where)
       expect(Store).to receive(:where).with(subdomain: subdomain).and_return([store])
       code, env = middleware.call(env_for("http://#{subdomain}.example.com"))
-      expect(env['X-Houser-Subdomain']).to eq(subdomain)
-      expect(env['X-Houser-Object']).to eq(store)
+      expect(env['Houser-Namespace']).to eq(subdomain)
+      expect(env['Houser-Object']).to eq(store)
     end
   end
 
@@ -94,8 +94,8 @@ describe Houser::Middleware do
     it "supports more than one-level of TLD" do
       expect(Account).to_not receive(:where)
       code, env = middleware.call(env_for("http://example.co.uk"))
-      expect(env['X-Houser-Subdomain']).to be_nil
-      expect(env['X-Houser-ID']).to be_nil
+      expect(env['Houser-Namespace']).to be_nil
+      expect(env['Houser-ID']).to be_nil
     end
 
     context "double subdomain" do
@@ -105,8 +105,8 @@ describe Houser::Middleware do
         account = double(id: 1)
         expect(Account).to receive(:where).with(subdomain: subdomain).and_return([account])
         code, env = middleware.call(env_for("http://#{subdomain}.example.co.uk"))
-        expect(env['X-Houser-Subdomain']).to eq(subdomain)
-        expect(env['X-Houser-Object']).to eq(account)
+        expect(env['Houser-Namespace']).to eq(subdomain)
+        expect(env['Houser-Object']).to eq(account)
       end
     end
   end
@@ -123,8 +123,8 @@ describe Houser::Middleware do
       account = double(id: 1)
       expect(Account).to receive(:where).with(:foo => subdomain).and_return([account])
       code, env = middleware.call(env_for("http://#{subdomain}.example.com"))
-      expect(env['X-Houser-Subdomain']).to eq(subdomain)
-      expect(env['X-Houser-Object']).to eq(account)
+      expect(env['Houser-Namespace']).to eq(subdomain)
+      expect(env['Houser-Object']).to eq(account)
     end
   end
 end


### PR DESCRIPTION
Two reasons to make this change:
1. [X Headers are not advised and are deprecated](http://www.ietf.org/rfc/rfc6648.txt)
2. You might not do a subdomain, but rather a sub-subdomain or even fqdn as the namespace. In this case namespace makes more sense semantically.
